### PR TITLE
v3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1bc89c12c4bf44b49b28161f328e49b0)](https://www.codacy.com/app/jackyaz/ntpMerlin?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=jackyaz/ntpMerlin&amp;utm_campaign=Badge_Grade)
 [![Build Status](https://travis-ci.com/jackyaz/ntpMerlin.svg?branch=master)](https://travis-ci.com/jackyaz/ntpMerlin)
 
-## v3.2.0
-### Updated on 2021-01-21
+## v3.2.1
+### Updated on 2021-02-07
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 
@@ -48,12 +48,4 @@ If this does not work, you will need to use the full path:
 ![CLI UI](https://puu.sh/GFJD7/b48a8bf2bf.png)
 
 ## Help
-Please post about any issues and problems here: [ntpMerlin on SNBForums](https://www.snbforums.com/threads/ntpmerlin-ntp-daemon-for-asuswrt-merlin.55756/)
-
-## FAQs
-### I haven't used scripts before on AsusWRT-Merlin
-If this is the first time you are using scripts, don't panic! In your router's WebUI, go to the Administration area of the left menu, and then the System tab. Set Enable JFFS custom scripts and configs to Yes.
-
-Further reading about scripts is available here: [AsusWRT-Merlin User-scripts](https://github.com/RMerl/asuswrt-merlin/wiki/User-scripts)
-
-![WebUI enable scripts](https://puu.sh/A3wnG/00a43283ed.png)
+Please post about any issues and problems here: [Asuswrt-Merlin AddOns on SNBForums](https://www.snbforums.com/forums/asuswrt-merlin-addons.60/)

--- a/S77chronyd
+++ b/S77chronyd
@@ -1,42 +1,17 @@
 #!/bin/sh
-
 # shellcheck disable=SC2034
+ln -s /jffs/addons/ntpmerlin.d/timeserverd /opt/bin 2>/dev/null
+chmod 0755 /opt/bin/timeserverd
 
-if [ "$1" = "start" ] || [ "$1" = "restart" ]; then
-	# Wait for NTP before starting
-	logger -st "S77chronyd" "Waiting for NTP to sync before starting..."
-	ntptimer=0
-	while [ "$(nvram get ntp_ready)" = "0" ] && [ "$ntptimer" -lt "300" ]; do
-		ntptimer=$((ntptimer+1))
-		sleep 1
-	done
-
-	if [ "$ntptimer" -ge "300" ]; then
-		logger -st "S77chronyd" "NTP failed to sync after 5 minutes - please check immediately!"
-		exit 1
-	fi
+if [ "$1" = "stop" ] || [ "$1" = "kill" ]; then
+	killall -q timeserverd
+	killall -q chronyd
 fi
 
-if [ -f "/opt/share/ntpmerlin.d/config" ]; then
-	SCRIPT_STORAGE_DIR="/opt/share/ntpmerlin.d"
-else
-	SCRIPT_STORAGE_DIR="/jffs/addons/ntpmerlin.d"
-fi
-
-if [ -f "/opt/etc/init.d/S06chronyd" ]; then
-	rm -f "/opt/etc/init.d/S06chronyd"
-fi
-
-mkdir -p /opt/var/lib/chrony
-mkdir -p /opt/var/run/chrony
-chown -R nobody:nobody /opt/var/lib/chrony
-chown -R nobody:nobody /opt/var/run/chrony
-chmod -R 770 /opt/var/lib/chrony
-chmod -R 770 /opt/var/run/chrony
 
 ENABLED=yes
-PROCS=chronyd
-ARGS="-r -u nobody -f $SCRIPT_STORAGE_DIR/chrony.conf"
+PROCS=timeserverd
+ARGS="S77chronyd"
 PREARGS=""
 PRECMD="killall ntp && killall ntpd"
 POSTCMD=""

--- a/S77ntpd
+++ b/S77ntpd
@@ -1,31 +1,16 @@
 #!/bin/sh
-
 # shellcheck disable=SC2034
+ln -s /jffs/addons/ntpmerlin.d/timeserverd /opt/bin 2>/dev/null
+chmod 0755 /opt/bin/timeserverd
 
-if [ "$1" = "start" ] || [ "$1" = "restart" ]; then
-	# Wait for NTP before starting
-	logger -st "S77ntpd" "Waiting for NTP to sync before starting..."
-	ntptimer=0
-	while [ "$(nvram get ntp_ready)" = "0" ] && [ "$ntptimer" -lt "300" ]; do
-		ntptimer=$((ntptimer+1))
-		sleep 1
-	done
-
-	if [ "$ntptimer" -ge "300" ]; then
-		logger -st "S77ntpd" "NTP failed to sync after 5 minutes - please check immediately!"
-		exit 1
-	fi
-fi
-
-if [ -f "/opt/share/ntpmerlin.d/config" ]; then
-	SCRIPT_STORAGE_DIR="/opt/share/ntpmerlin.d"
-else
-	SCRIPT_STORAGE_DIR="/jffs/addons/ntpmerlin.d"
+if [ "$1" = "stop" ] || [ "$1" = "kill" ]; then
+	killall -q timeserverd
+	killall -q ntpd
 fi
 
 ENABLED=yes
-PROCS=ntpd
-ARGS="-c $SCRIPT_STORAGE_DIR/ntp.conf -g"
+PROCS=timeserverd
+ARGS="S77ntpd"
 PREARGS=""
 PRECMD="killall ntp && killall ntpd"
 POSTCMD=""

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -1032,6 +1032,9 @@ Process_Upgrade(){
 		"$SQLITE3_PATH" "$SCRIPT_STORAGE_DIR/ntpdstats.db" < /tmp/ntp-stats.sql >/dev/null 2>&1
 		touch "$SCRIPT_STORAGE_DIR/.tableupgraded"
 	fi
+	if [ ! -f "$SCRIPT_DIR/timeserverd" ]; then
+		Update_File timeserverd
+	fi
 }
 
 PressEnter(){

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -21,7 +21,7 @@
 readonly SCRIPT_NAME="ntpMerlin"
 readonly SCRIPT_NAME_LOWER=$(echo $SCRIPT_NAME | tr 'A-Z' 'a-z' | sed 's/d//')
 readonly SCRIPT_VERSION="v3.2.1"
-SCRIPT_BRANCH="develop"
+SCRIPT_BRANCH="master"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
 readonly SCRIPT_WEBPAGE_DIR="$(readlink /www/user)"

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -631,19 +631,23 @@ Get_WebUI_Page(){
 	done
 }
 
+### locking mechanism code credit to Martineau (@MartineauUK) ###
 Mount_WebUI(){
+	LOCKFILE=/tmp/addonwebui.lock
+	FD=386
+	eval exec "$FD>$LOCKFILE"
+	flock -x "$FD"
 	Get_WebUI_Page "$SCRIPT_DIR/ntpdstats_www.asp"
 	if [ "$MyPage" = "none" ]; then
 		Print_Output true "Unable to mount $SCRIPT_NAME WebUI page, exiting" "$CRIT"
-		Clear_Lock
-		exit 1
+		flock -u "$FD"
+		return 1
 	fi
-	Print_Output true "Mounting $SCRIPT_NAME WebUI page as $MyPage" "$PASS"
+	
 	cp -f "$SCRIPT_DIR/ntpdstats_www.asp" "$SCRIPT_WEBPAGE_DIR/$MyPage"
 	echo "ntpMerlin" > "$SCRIPT_WEBPAGE_DIR/$(echo $MyPage | cut -f1 -d'.').title"
 	
 	if [ "$(uname -o)" = "ASUSWRT-Merlin" ]; then
-		
 		if [ ! -f /tmp/index_style.css ]; then
 			cp -f /www/index_style.css /tmp/
 		fi
@@ -674,6 +678,8 @@ Mount_WebUI(){
 		umount /www/require/modules/menuTree.js 2>/dev/null
 		mount -o bind /tmp/menuTree.js /www/require/modules/menuTree.js
 	fi
+	flock -u "$FD"
+	Print_Output true "Mounted $SCRIPT_NAME WebUI page as $MyPage" "$PASS"
 }
 
 TimeServer_Customise(){

--- a/timeserverd
+++ b/timeserverd
@@ -1,0 +1,61 @@
+#!/bin/sh
+#shellcheck disable=SC2039
+trap '' SIGHUP
+
+# Wait for NTP before starting
+logger -st "timeserverd" "Waiting for NTP to sync before starting..."
+ntptimer=0
+while [ "$(nvram get ntp_ready)" -eq 0 ] && [ "$ntptimer" -lt 300 ]; do
+	ntptimer=$((ntptimer+1))
+	sleep 1
+done
+
+if [ "$ntptimer" -ge 300 ]; then
+	logger -st "timeserverd" "NTP failed to sync after 5 minutes - please check immediately!"
+	exit 1
+fi
+
+if [ -f "/opt/share/ntpmerlin.d/config" ]; then
+	SCRIPT_STORAGE_DIR="/opt/share/ntpmerlin.d"
+else
+	SCRIPT_STORAGE_DIR="/jffs/addons/ntpmerlin.d"
+fi
+
+if [ "$1" = "S77ntpd" ]; then
+	ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
+	
+	while true; do
+		sleep 5
+		if [ "$(pidof ntpd | wc -w)" -lt 1 ]; then
+			logger -t "timeserverd" "ntpd dead, restarting..."
+			killall -q ntpd
+			sleep 5
+			ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
+			logger -t "timeserverd" "ntpd restarted"
+		fi
+	done
+elif [ "$1" = "S77chronyd" ]; then
+	if [ -f "/opt/etc/init.d/S06chronyd" ]; then
+		rm -f "/opt/etc/init.d/S06chronyd"
+	fi
+	
+	mkdir -p /opt/var/lib/chrony
+	mkdir -p /opt/var/run/chrony
+	chown -R nobody:nobody /opt/var/lib/chrony
+	chown -R nobody:nobody /opt/var/run/chrony
+	chmod -R 770 /opt/var/lib/chrony
+	chmod -R 770 /opt/var/run/chrony
+	
+	chronyd -r -u nobody -f "$SCRIPT_STORAGE_DIR/chrony.conf" > /dev/null 2>&1 &
+	
+	while true; do
+		sleep 5
+		if [ "$(pidof chronyd | wc -w)" -lt 1 ]; then
+			logger -t "timeserverd" "chronyd dead, restarting..."
+			killall -q chronyd
+			sleep 5
+			ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
+			logger -t "timeserverd" "chronyd restarted"
+		fi
+	done
+fi


### PR DESCRIPTION
FIXED: S77ntpd/S77chronyd could cause post-mount to overrun a 120 second timeout while waiting for NTP sync and block execution of other scripts/commands