### PR TITLE
v3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/jackyaz/ntpMerlin.svg?branch=master)](https://travis-ci.com/jackyaz/ntpMerlin)
 
 ## v3.3.0
-### Updated on 2021-04-09
+### Updated on 2021-04-10
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1bc89c12c4bf44b49b28161f328e49b0)](https://www.codacy.com/app/jackyaz/ntpMerlin?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=jackyaz/ntpMerlin&amp;utm_campaign=Badge_Grade)
 [![Build Status](https://travis-ci.com/jackyaz/ntpMerlin.svg?branch=master)](https://travis-ci.com/jackyaz/ntpMerlin)
 
-## v3.2.3
-### Updated on 2021-03-24
+## v3.3.0
+### Updated on 2021-04-09
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -1097,22 +1097,6 @@ Shortcut_Script(){
 }
 
 Process_Upgrade(){
-	if [ ! -f "$SCRIPT_STORAGE_DIR/.tableupgraded" ]; then
-		{
-			echo "ALTER TABLE ntpstats RENAME COLUMN [Frequency] TO [Sys_Jitter2];"
-			echo "ALTER TABLE ntpstats RENAME COLUMN [Sys_Jitter] TO [Clk_Jitter2];"
-			echo "ALTER TABLE ntpstats RENAME COLUMN [Clk_Jitter] TO [Clk_Wander2];"
-			echo "ALTER TABLE ntpstats RENAME COLUMN [Clk_Wander] TO [Frequency2];"
-			echo "ALTER TABLE ntpstats RENAME COLUMN [Sys_Jitter2] TO [Sys_Jitter];"
-			echo "ALTER TABLE ntpstats RENAME COLUMN [Clk_Jitter2] TO [Clk_Jitter];"
-			echo "ALTER TABLE ntpstats RENAME COLUMN [Clk_Wander2] TO [Clk_Wander];"
-			echo "ALTER TABLE ntpstats RENAME COLUMN [Frequency2] TO [Frequency];"
-		} > /tmp/ntp-stats.sql
-		"$SQLITE3_PATH" "$SCRIPT_STORAGE_DIR/ntpdstats.db" < /tmp/ntp-stats.sql >/dev/null 2>&1
-		touch "$SCRIPT_STORAGE_DIR/.tableupgraded"
-	fi
-	if [ ! -f "$SCRIPT_DIR/timeserverd" ]; then
-		Update_File timeserverd
 	fi
 }
 

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -24,7 +24,7 @@
 readonly SCRIPT_NAME="ntpMerlin"
 readonly SCRIPT_NAME_LOWER=$(echo $SCRIPT_NAME | tr 'A-Z' 'a-z' | sed 's/d//')
 readonly SCRIPT_VERSION="v3.3.0"
-SCRIPT_BRANCH="develop"
+SCRIPT_BRANCH="master"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
 readonly SCRIPT_WEBPAGE_DIR="$(readlink /www/user)"

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -1107,12 +1107,13 @@ Shortcut_Script(){
 Process_Upgrade(){
 	if [ ! -f "$SCRIPT_STORAGE_DIR/.chronyugraded" ]; then
 		if [ "$(TimeServer check)" = "chronyd" ]; then
-			Print_Output true "Checking if chrony-nts is available for your router..."
-			opkg update
+			Print_Output true "Checking if chrony-nts is available for your router..." "$PASS"
+			opkg update >/dev/null 2>&1
 			if [ -n "$(opkg info chrony-nts)" ]; then
-				Print_Output true "chrony-nts is available, replacing chrony with chrony-nts..."
-				opkg remove chrony
-				opkg install chrony-nts
+				Print_Output true "chrony-nts is available, replacing chrony with chrony-nts..." "$PASS"
+				/opt/etc/init.d/S77chronyd stop >/dev/null 2>&1
+				opkg remove chrony >/dev/null 2>&1
+				opkg install chrony-nts >/dev/null 2>&1
 				Update_File chrony.conf >/dev/null 2>&1
 				Update_File S77chronyd >/dev/null 2>&1
 			fi

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -1117,6 +1117,8 @@ Process_Upgrade(){
 				opkg install chrony-nts >/dev/null 2>&1
 				Update_File chrony.conf >/dev/null 2>&1
 				Update_File S77chronyd >/dev/null 2>&1
+			else
+				Print_Output true "chrony-nts not found in Entware for your router" "$WARN"
 			fi
 			touch "$SCRIPT_STORAGE_DIR/.chronyugraded"
 		fi

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -1112,6 +1112,7 @@ Process_Upgrade(){
 			if [ -n "$(opkg info chrony-nts)" ]; then
 				Print_Output true "chrony-nts is available, replacing chrony with chrony-nts..." "$PASS"
 				/opt/etc/init.d/S77chronyd stop >/dev/null 2>&1
+				rm -f /opt/etc/init.d/S77chronyd
 				opkg remove chrony >/dev/null 2>&1
 				opkg install chrony-nts >/dev/null 2>&1
 				Update_File chrony.conf >/dev/null 2>&1

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -23,8 +23,8 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="ntpMerlin"
 readonly SCRIPT_NAME_LOWER=$(echo $SCRIPT_NAME | tr 'A-Z' 'a-z' | sed 's/d//')
-readonly SCRIPT_VERSION="v3.2.3"
-SCRIPT_BRANCH="master"
+readonly SCRIPT_VERSION="v3.3.0"
+SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
 readonly SCRIPT_WEBPAGE_DIR="$(readlink /www/user)"

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -882,7 +882,11 @@ TimeServer(){
 			rm -f /opt/etc/init.d/S77ntpd
 			if [ ! -f /opt/sbin/chronyd ]; then
 				opkg update
-				opkg install chrony
+				if [ -n "$(opkg info chrony-nts)" ]; then
+					opkg install chrony-nts
+				else
+					opkg install chrony
+				fi
 			fi
 			Update_File chrony.conf >/dev/null 2>&1
 			Update_File S77chronyd >/dev/null 2>&1


### PR DESCRIPTION
NEW: Support for NTS. If your router supports the NTS version of chrony it will be installed automatically. To use an NTS server, you can uncomment (delete the ! at the start of the line) the below lines in chrony.conf (menu option 3 on the command line):

```sh
pool time.cloudflare.com iburst nts

ntsdumpdir /opt/var/lib/chrony
```