### PR TITLE
Use pool directive in ntp.conf

### DIFF
--- a/ntp.conf
+++ b/ntp.conf
@@ -1,10 +1,7 @@
 
-# replace the following time servers to the ones close to you
+# replace the following with time servers or pools close to you
 # see http://support.ntp.org/bin/view/Servers/NTPPoolServers
-server 0.pool.ntp.org iburst
-server 1.pool.ntp.org iburst
-server 2.pool.ntp.org iburst
-server 3.pool.ntp.org iburst
+pool pool.ntp.org iburst
 
 interface ignore wildcard
 interface listen br0


### PR DESCRIPTION
Using multiple `server N.X.pool.ntp.org` directives is rather old-school - it's what was needed to make the NTP pool work originally with ntpd.

Any vaguely modern ntpd version (and that includes what ntpMerlin installed on my RT-N66U) has a specific `pool` directive that works better - it knows how to round-robin and retry and get as many servers from DNS queries as it needs, unlike `server` which just latches onto the first DNS response and sticks with it even if not responding, hence needing the multiple lines. It seems chrony.conf is already using `pool`.

One possible remaining need for wanting to use a number would be to use IPv6 - it's still the case that only the `2` pools returns IPv6 addresses, so if you wanted to allow IPv6, the single line`pool 2.pool.ntp.org` would be appropriate, and IPv6-only would need `pool -6 2.pool.ntp.org`.