### PR TITLE
Text alignment fix for longer model names

### DIFF
--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -1312,7 +1312,7 @@ ScriptHeader(){
 	printf "${BOLD}##               | |                                        ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##               |_|                                        ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##                                                          ##${CLEARFORMAT}\\n"
-	printf "${BOLD}##                   %s on %-11s                  ##${CLEARFORMAT}\\n" "$SCRIPT_VERSION" "$ROUTER_MODEL"
+	printf "${BOLD}##                   %s on %-16s             ##${CLEARFORMAT}\\n" "$SCRIPT_VERSION" "$ROUTER_MODEL"
 	printf "${BOLD}##                                                          ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##         https://github.com/jackyaz/ntpMerlin             ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##                                                          ##${CLEARFORMAT}\\n"

--- a/timeserverd
+++ b/timeserverd
@@ -7,7 +7,7 @@ logger -st timeserverd "Waiting for NTP to sync before starting..."
 ntpwaitcount=0
 while [ "$(nvram get ntp_ready)" -eq 0 ] && [ "$ntpwaitcount" -lt 600 ]; do
 	ntpwaitcount="$((ntpwaitcount + 30))"
-	Print_Output true "Waiting for NTP to sync..." "$WARN"
+	logger -st timeserverd "Waiting for NTP to sync..."
 	sleep 30
 done
 


### PR DESCRIPTION
Fix spacing in title card for longer model names such as RT-AX86U_Pro

![image](https://github.com/jackyaz/ntpMerlin/assets/35944068/286753e1-b500-4779-a5c8-9f61ae8b6e57)
